### PR TITLE
fix: add extends

### DIFF
--- a/net.krafting.SemantiK.Lang.French.metainfo.xml
+++ b/net.krafting.SemantiK.Lang.French.metainfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="addon">
   <id>net.krafting.SemantiK.Lang.French</id>
+  <extends>net.krafting.SemantiK</extends>
   <name>SemantiK French Language Pack</name>
   <summary>French language pack for SemantiK</summary>
   <summary xml:lang="fr">Pack de langue française pour SemantiK</summary>


### PR DESCRIPTION
Add `extends` to metainfo to resolve the below warning:
```shell
> LANG=C flatpak remote-ls --updates

(flatpak remote-ls:2589130): As-WARNING **: 22:12:16.120: net.krafting.SemantiK.Lang.French was of type addon but had no extends
```

Refs:
- https://github.com/flathub/net.krafting.SemantiK.Lang.English/issues/1
  - https://github.com/flathub/net.krafting.SemantiK.Lang.English/pull/2

Fixes #2 